### PR TITLE
fix: DMA_BUFF NS support for Kernel 6.13+

### DIFF
--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -54,7 +54,11 @@
 #include <linux/vmalloc.h>
 
 #if __has_include(<linux/dma-buf.h>)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS("DMA_BUF");
+#else
 MODULE_IMPORT_NS(DMA_BUF);
+#endif
 #endif
 
 #include "gasket_constants.h"


### PR DESCRIPTION
All credits go to @UmbraMalison

https://github.com/KyleGospo/gasket-dkms/pull/18